### PR TITLE
Allow for import of 2016 Events

### DIFF
--- a/app/src/main/java/com/team2052/frckrawler/GlobalValues.java
+++ b/app/src/main/java/com/team2052/frckrawler/GlobalValues.java
@@ -13,6 +13,6 @@ public class GlobalValues {
      * most recently connected server
      */
     public static final String MAC_ADDRESS_PREF = "MACAddress";
-    public static final int MAX_COMP_YEAR = 2015;
+    public static final int MAX_COMP_YEAR = 2016;
     public static final int FIRST_COMP_YEAR = 1992;
 }


### PR DESCRIPTION
Changes hardcoded year limit from 2015 to 2016 to allow for event import. Addresses #9