### PR TITLE
Disable Ad ID collection for Firebase

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,5 +99,7 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
+
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
     </application>
 </manifest>


### PR DESCRIPTION
Fixes our compliance with Google Play's Ad ID policy by simply not using the Ad ID.