### PR TITLE
Support changing the server device

### DIFF
--- a/app/src/main/java/com/team2052/frckrawler/bluetooth/client/ScoutSyncHandler.java
+++ b/app/src/main/java/com/team2052/frckrawler/bluetooth/client/ScoutSyncHandler.java
@@ -44,6 +44,7 @@ public class ScoutSyncHandler {
         dialog.setMessage(String.format("Are you sure you want to sync to %s?", device.getName()));
         dialog.setPositiveButton("Yes", (dialog1, which) -> startSyncConsumer.call(device));
         dialog.setNegativeButton("No", null);
+        dialog.setNeutralButton("Change Server", (dialog1, which) -> showDeviceListDialog(context, startSyncConsumer));
         dialog.create().show();
     }
 


### PR DESCRIPTION
When performing a sync, scout devices now have the option to change the server they are syncing to.

Resolves #42 and #43 