### PR TITLE
Dark mode toolbar color

### DIFF
--- a/app/src/main/res/layout/mode_select_fragment.xml
+++ b/app/src/main/res/layout/mode_select_fragment.xml
@@ -5,6 +5,15 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        custom:layout_constraintEnd_toEndOf="parent"
+        custom:layout_constraintStart_toStartOf="parent"
+        custom:layout_constraintTop_toTopOf="parent"
+        custom:title="@string/app_name" />
 
     <TextView
         android:id="@+id/textView"
@@ -13,7 +22,7 @@
         android:layout_margin="16dp"
         android:text="Welcome to FRC Krawler! To get started, select from the options below"
         android:textAlignment="center"
-        android:textSize="16dp" />
+        android:textSize="16sp" />
 
     <com.team2052.frckrawler.views.ExpandableCard
         android:id="@+id/remote_scout_expandable"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/nav_graph"
-  app:startDestination="@id/sampleFragment">
+  app:startDestination="@id/modeSelectFragment">
 
   <fragment
     android:id="@+id/sampleFragment"
@@ -18,4 +18,8 @@
       android:id="@+id/sampleFragment2"
       android:name="com.team2052.frckrawler.sample.SampleFragment2"
       android:label="SampleFragment2" />
+  <fragment
+      android:id="@+id/modeSelectFragment"
+      android:name="com.team2052.frckrawler.modeSelect.ModeSelectFragment"
+      android:label="ModeSelectFragment" />
 </navigation>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools"> q
     <!-- Base application theme. -->
-    <style name="Theme.FRCKrawler" parent="Theme.MaterialComponents">
+    <style name="Theme.FRCKrawler" parent="Theme.MaterialComponents.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/maroon_200</item>
         <item name="colorPrimaryVariant">@color/maroon_500</item>
@@ -11,7 +11,5 @@
         <item name="colorOnSecondary">@color/black_000</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
-        <item name="android:actionBarStyle">@style/Theme.MaterialComponents.DayNight.DarkActionBar</item>
     </style>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-beta02'
+        classpath 'com.android.tools.build:gradle:4.2.0-beta04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Fixes toolbar color for the mode select screen- this includes:
 * Added explicit `Toolbar` to the mode select screen's layout XML file (see next bullet)
 * Changedtheme to `Theme.MaterialComponents.NoActionBar`. The `Theme.MaterialComponents` that we had adds a default toolbar to the activity, but we want to control the Toolbar directly.


Two unrelated changes I made:
 * Updated Android Gradle Plugin to beta 4
 * Set mode select screen as the "home" screen
 

Here's what it looks like now:
 
![dark_toolbar](https://user-images.githubusercontent.com/3267925/106538977-c535c300-64c2-11eb-95e0-00abb57cce85.png)
