### PR TITLE
Enable Jetpack Compose and create Compose foundation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        compose true
     }
 
     defaultConfig {
@@ -25,16 +26,19 @@ android {
     packagingOptions {
         exclude "META-INF/atomicfu.kotlin_module"
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = "1.8"
     }
@@ -60,6 +64,16 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.constraint_layout_version"
     implementation "androidx.navigation:navigation-fragment-ktx:2.3.2"
     implementation "androidx.navigation:navigation-ui-ktx:2.3.2"
+
+    // Compose
+    implementation "androidx.compose.ui:ui:${rootProject.compose_version}"
+    implementation "androidx.compose.ui:ui-tooling:${rootProject.compose_version}"
+    implementation "androidx.compose.foundation:foundation:${rootProject.compose_version}"
+    implementation "androidx.compose.material:material:${rootProject.compose_version}"
+    implementation "androidx.compose.material:material-icons-core:${rootProject.compose_version}"
+    implementation "androidx.compose.material:material-icons-extended:${rootProject.compose_version}"
+    implementation 'androidx.activity:activity-compose:1.3.0-alpha04'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha03'
 
     // Room components
     implementation "androidx.room:room-runtime:$rootProject.room_version"

--- a/app/src/main/java/com/team2052/frckrawler/compose/theme/Color.kt
+++ b/app/src/main/java/com/team2052/frckrawler/compose/theme/Color.kt
@@ -1,0 +1,9 @@
+package com.team2052.frckrawler.compose.theme
+
+import androidx.compose.ui.graphics.Color
+
+val maroon200 = Color(0xFFF450000)
+val maroon500 = Color(0xFF2A0000)
+val yellow200 = Color(0xFFFFD740)
+val black121 = Color(0xFF121212)
+val redError = Color(0xFFFCf6679)

--- a/app/src/main/java/com/team2052/frckrawler/compose/theme/Shape.kt
+++ b/app/src/main/java/com/team2052/frckrawler/compose/theme/Shape.kt
@@ -1,0 +1,11 @@
+package com.team2052.frckrawler.compose.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Shapes
+import androidx.compose.ui.unit.dp
+
+val shapes = Shapes(
+    small = RoundedCornerShape(4.dp),
+    medium = RoundedCornerShape(4.dp),
+    large = RoundedCornerShape(0.dp)
+)

--- a/app/src/main/java/com/team2052/frckrawler/compose/theme/Theme.kt
+++ b/app/src/main/java/com/team2052/frckrawler/compose/theme/Theme.kt
@@ -1,0 +1,39 @@
+package com.team2052.frckrawler.compose.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val DarkColorPalette = darkColors(
+    primary = maroon200,
+    primaryVariant = maroon500,
+    onPrimary = Color.White,
+    secondary = yellow200,
+    onSecondary = Color.Black
+)
+
+private val LightColorPalette = lightColors(
+    primary = maroon200,
+    primaryVariant = maroon500,
+    onPrimary = Color.White,
+    secondary = yellow200,
+    onSecondary = Color.Black
+)
+
+@Composable
+fun FrcKrawlerTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {
+    val colors = if (darkTheme) {
+        DarkColorPalette
+    } else {
+        LightColorPalette
+    }
+
+    MaterialTheme(
+        colors = colors,
+        shapes = shapes,
+        content = content
+    )
+}

--- a/app/src/main/java/com/team2052/frckrawler/sample/SampleFragment2.kt
+++ b/app/src/main/java/com/team2052/frckrawler/sample/SampleFragment2.kt
@@ -6,25 +6,34 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
 import com.team2052.frckrawler.R
+import com.team2052.frckrawler.compose.theme.FrcKrawlerTheme
 import com.team2052.frckrawler.databinding.SampleFragment2Binding
 import com.team2052.frckrawler.databinding.SampleFragmentBinding
 
 class SampleFragment2 : Fragment() {
 
-  private lateinit var viewModel: SampleViewModel
-  private var binding: SampleFragment2Binding? = null
-
   override fun onCreateView(
     inflater: LayoutInflater, container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
-    binding = SampleFragment2Binding.inflate(inflater, container, false)
-    return binding!!.root
+    return ComposeView(requireContext()).apply {
+      setContent {
+        SampleComposable()
+      }
+    }
   }
+}
 
-  override fun onDestroyView() {
-    super.onDestroyView()
-    binding = null
+@Composable
+private fun SampleComposable() {
+  FrcKrawlerTheme {
+    Surface {
+      Text("Hello from Jetpack Compose!")
+    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.20"
+    ext.kotlin_version = "1.4.30"
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-beta04'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha11'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -27,10 +27,12 @@ task clean(type: Delete) {
 
 ext {
     core_ktx_version = "1.3.2"
-    appCompat_version = "1.2.0"
+    appCompat_version = "1.3.0-beta01"
     room_version = "2.2.5"
     material_version = "1.2.1"
     constraint_layout_version = "2.0.4"
+    compose_version = "1.0.0-beta02"
+
     // Testing versions
     junit_version = "4.+"
     espresso_version = "3.3.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Dec 07 19:29:50 CST 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR does a few things to enable us to use Jetpack Compose:

 * Update the Android Gradle Plugin to 7.0.0
 * Enable Compose and pull in Compose libraries
 * Setup our Compose Material theme
 * Update `SampleFragment2` with some Compose content as an example