### PR TITLE
Set up bluetooth sync server and associated permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.team2052.frckrawler"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         buildConfigField "int", "MIN_SDK_VERSION", "$minSdkVersion.apiLevel"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,30 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.team2052.frckrawler">
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.team2052.frckrawler">
+    <!-- Request legacy Bluetooth permissions on older devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+      android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+      android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
+      android:maxSdkVersion="26" />
+
+    <!-- Modern Bluetooth permissions -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+      android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <uses-feature android:name="android.hardware.bluetooth" android:required="true" />
+    <uses-feature
+      android:name="android.hardware.bluetooth"
+      android:required="true" />
 
     <application
-        android:name=".FRCKrawlerApp"
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.FRCKrawlerSplash">
-
+      android:name=".FRCKrawlerApp"
+      android:allowBackup="true"
+      android:icon="@mipmap/ic_launcher"
+      android:label="@string/app_name"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:supportsRtl="true"
+      android:theme="@style/Theme.FRCKrawlerSplash">
         <activity
-            android:name=".ui.MainActivity"
-            android:exported="true">
+          android:name=".ui.MainActivity"
+          android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+          android:name=".bluetooth.server.SyncServerService"
+          android:enabled="true"
+          android:exported="false"
+          android:foregroundServiceType="connectedDevice|dataSync"/>
     </application>
+
 </manifest>

--- a/app/src/main/java/com/team2052/frckrawler/bluetooth/BluetoothController.kt
+++ b/app/src/main/java/com/team2052/frckrawler/bluetooth/BluetoothController.kt
@@ -1,72 +1,54 @@
 package com.team2052.frckrawler.bluetooth
 
-import android.app.Activity
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.content.Context
 import android.content.Intent
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.runtime.Composable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.Closeable
 import javax.inject.Inject
 
 class BluetoothController @Inject constructor(
     @ApplicationContext private val context: Context,
-    val bluetooth: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter(),
+    val bluetoothAdapter: BluetoothAdapter,
 ) : Closeable {
 
     fun enableBluetooth() {
-        requireBluetooth { bluetooth ->
-            if (!bluetooth.isEnabled) bluetooth.enable()
-        }
+        if (!bluetoothAdapter.isEnabled) bluetoothAdapter.enable()
     }
 
     fun disableBluetooth() {
-        requireBluetooth { bluetooth ->
-            if (bluetooth.isEnabled) bluetooth.disable()
-        }
+        if (!bluetoothAdapter.isEnabled) bluetoothAdapter.disable()
     }
 
     fun toggleBluetooth(state: Boolean) {
-        requireBluetooth { bluetooth ->
-            if (bluetooth.isEnabled != state) {
-                if (state) bluetooth.enable() else bluetooth.disable()
-            }
+        if (bluetoothAdapter.isEnabled != state) {
+            if (state) bluetoothAdapter.enable() else bluetoothAdapter.disable()
         }
     }
 
     fun bluetoothEnabled(): Boolean {
-        return requireBluetooth { bluetooth ->
-            bluetooth.isEnabled
-        } ?: false
+        return bluetoothAdapter.isEnabled
     }
 
     fun bondedDevices(): Set<BluetoothDevice> {
-        return requireBluetooth { bluetooth ->
-            bluetooth.bondedDevices
-        } ?: emptySet()
+        return bluetoothAdapter.bondedDevices
     }
 
     fun makeDiscoverable(duration: Int) {
-        requireBluetooth {
-            val discoverableIntent: Intent = Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE).apply {
-                putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, duration)
-            }.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) // TODO: find better way to do this
-            context.startActivity(discoverableIntent)
-        }
+        val discoverableIntent: Intent = Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE).apply {
+            putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, duration)
+        }.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) // TODO: find better way to do this
+        context.startActivity(discoverableIntent)
+
     }
 
     fun startDiscovery(onDeviceFound: (BluetoothDevice) -> Unit) {
-        requireBluetooth { bluetooth ->
-            if (cancelDiscovery()) bluetooth.startDiscovery()
-        }
+        if (cancelDiscovery()) bluetoothAdapter.startDiscovery()
     }
 
-    fun cancelDiscovery(): Boolean =
-        requireBluetooth { bluetooth ->
-            bluetooth.cancelDiscovery()
-        } ?: false
+    fun cancelDiscovery(): Boolean = bluetoothAdapter.cancelDiscovery()
+
 
     fun bond(device: BluetoothDevice) : Boolean {
         cancelDiscovery()
@@ -74,10 +56,7 @@ class BluetoothController @Inject constructor(
     }
 
     fun bonded(device: BluetoothDevice) : Boolean =
-        bluetooth?.bondedDevices?.contains(device) ?: false
-
-    private inline fun <T> requireBluetooth(block: (BluetoothAdapter) -> T): T? =
-        if (bluetooth != null && bluetoothAvailable) { block(bluetooth) } else { null }
+        bluetoothAdapter.bondedDevices?.contains(device) ?: false
 
     override fun close() {
         cancelDiscovery()

--- a/app/src/main/java/com/team2052/frckrawler/bluetooth/BluetoothSyncConstants.kt
+++ b/app/src/main/java/com/team2052/frckrawler/bluetooth/BluetoothSyncConstants.kt
@@ -1,0 +1,8 @@
+package com.team2052.frckrawler.bluetooth
+
+import java.util.UUID
+
+object BluetoothSyncConstants {
+  const val ServiceName = "FRCKrawler"
+  val Uuid = UUID.fromString("d6035ed0-8f10-11e2-9e96-0800200c9a66")
+}

--- a/app/src/main/java/com/team2052/frckrawler/bluetooth/server/SyncServerService.kt
+++ b/app/src/main/java/com/team2052/frckrawler/bluetooth/server/SyncServerService.kt
@@ -1,0 +1,80 @@
+package com.team2052.frckrawler.bluetooth.server
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import com.team2052.frckrawler.R
+import com.team2052.frckrawler.notifications.FrcKrawlerNotificationChannel
+import com.team2052.frckrawler.notifications.NotificationChannelManager
+import com.team2052.frckrawler.ui.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/**
+ * Service that acts as a server for syncing with scouts. This server runs as a foreground service
+ * to allow syncing even when the app is not in the foreground.
+ *
+ * TODO add an action to the notification to stop the server?
+ */
+@AndroidEntryPoint
+class SyncServerService : Service() {
+
+  companion object {
+    private const val foregroundNotificationId = 2052
+
+    internal val ACTION_START = "com.team2052.frckrawler.bluetooth.server.START"
+    internal val ACTION_STOP = "com.team2052.frckrawler.bluetooth.server.STOP"
+  }
+
+  @Inject lateinit internal var notificationChannelManager: NotificationChannelManager
+
+  lateinit var serverThread: SyncServerThread
+
+  override fun onBind(intent: Intent): IBinder? {
+    return null
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    // We want to be able to finish syncing if the app goes in the background, so
+    // we run in the foreground
+    notificationChannelManager.ensureChannelsCreated()
+    startForeground(foregroundNotificationId, getForegroundNotification())
+    startServer()
+
+    return START_REDELIVER_INTENT
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+  }
+
+  private fun getForegroundNotification(): Notification {
+    // TODO format with actual number of connected clients
+    val notificationText = resources.getQuantityString(R.plurals.server_sync_clients_connected, 0, 0)
+
+    // TODO deep link to server screen
+    val pendingIntent: PendingIntent =
+      Intent(this, MainActivity::class.java).let { notificationIntent ->
+        PendingIntent.getActivity(this, 0, notificationIntent,
+          PendingIntent.FLAG_IMMUTABLE)
+      }
+
+    return Notification.Builder(this, FrcKrawlerNotificationChannel.Sync.id)
+      .setContentTitle(getText(R.string.server_sync_notification_title))
+      .setContentText(notificationText)
+      .setSmallIcon(R.drawable.ic_logo)
+      .setContentIntent(pendingIntent)
+      .build()
+  }
+
+  private fun startServer() {
+    serverThread = SyncServerThread(this)
+    serverThread.start()
+  }
+
+  private fun stopServer() {
+    serverThread.interrupt()
+  }
+}

--- a/app/src/main/java/com/team2052/frckrawler/bluetooth/server/SyncServerThread.kt
+++ b/app/src/main/java/com/team2052/frckrawler/bluetooth/server/SyncServerThread.kt
@@ -1,0 +1,42 @@
+package com.team2052.frckrawler.bluetooth.server
+
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothServerSocket
+import android.content.Context
+import com.team2052.frckrawler.bluetooth.BluetoothSyncConstants
+import timber.log.Timber
+
+class SyncServerThread(
+  context: Context
+) : Thread("frckrawler-sync-server") {
+  companion object {
+    private const val LOG_TAG = "SyncServer"
+  }
+
+  private val bluetoothManager: BluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+
+  private var serverSocket: BluetoothServerSocket? = null
+
+  override fun run() {
+    Timber.d("Opening server")
+
+    // TODO handle interrupt?
+    while (serverSocket == null) {
+      // TODO catch?
+      serverSocket = bluetoothManager.adapter.listenUsingRfcommWithServiceRecord(
+        BluetoothSyncConstants.ServiceName,
+        BluetoothSyncConstants.Uuid
+      )
+    }
+
+    // TODO handle interrupt?
+    while (true) {
+      val clientSocket = serverSocket!!.accept()
+      val clientDevice = clientSocket.remoteDevice
+      Timber.d("Client connected: ${clientDevice.name}")
+      // TODO perform sync
+    }
+  }
+
+  // TODO handle closing sockets?
+}

--- a/app/src/main/java/com/team2052/frckrawler/bluetooth/server/SyncServiceController.kt
+++ b/app/src/main/java/com/team2052/frckrawler/bluetooth/server/SyncServiceController.kt
@@ -1,0 +1,18 @@
+package com.team2052.frckrawler.bluetooth.server
+
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class SyncServiceController @Inject constructor(
+  @ApplicationContext private val context: Context
+){
+  fun startServer() {
+    context.startService(Intent(context, SyncServerService::class.java))
+  }
+
+  fun stopServer() {
+    context.stopService(Intent(context, SyncServerService::class.java))
+  }
+}

--- a/app/src/main/java/com/team2052/frckrawler/data/model/DeviceType.kt
+++ b/app/src/main/java/com/team2052/frckrawler/data/model/DeviceType.kt
@@ -1,0 +1,6 @@
+package com.team2052.frckrawler.data.model
+
+enum class DeviceType {
+  Client,
+  Server
+}

--- a/app/src/main/java/com/team2052/frckrawler/di/BluetoothModule.kt
+++ b/app/src/main/java/com/team2052/frckrawler/di/BluetoothModule.kt
@@ -1,6 +1,7 @@
 package com.team2052.frckrawler.di
 
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import com.team2052.frckrawler.bluetooth.BluetoothController
 import dagger.Module
@@ -19,6 +20,22 @@ object BluetoothModule {
         @ApplicationContext context: Context
     ) = BluetoothController(
         context = context,
-        bluetooth = BluetoothAdapter.getDefaultAdapter(),
+        bluetoothAdapter = BluetoothAdapter.getDefaultAdapter(),
     )
+
+    @Singleton
+    @Provides
+    fun provideBluetoothManager(
+        @ApplicationContext context: Context
+    ): BluetoothManager {
+        return context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+    }
+
+    @Singleton
+    @Provides
+    fun provideBluetoothAdapter(
+        manager: BluetoothManager
+    ): BluetoothAdapter {
+        return manager.adapter
+    }
 }

--- a/app/src/main/java/com/team2052/frckrawler/di/PermissionsModule.kt
+++ b/app/src/main/java/com/team2052/frckrawler/di/PermissionsModule.kt
@@ -1,0 +1,24 @@
+package com.team2052.frckrawler.di
+
+import android.bluetooth.BluetoothAdapter
+import android.content.Context
+import com.team2052.frckrawler.bluetooth.BluetoothController
+import com.team2052.frckrawler.ui.permissions.PermissionManager
+import com.team2052.frckrawler.ui.permissions.RealPermissionManager
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PermissionsModule {
+    @Binds
+    abstract fun bindPermissionManager(
+        manager: RealPermissionManager
+    ): PermissionManager
+
+}

--- a/app/src/main/java/com/team2052/frckrawler/notifications/FrcKrawlerNotificationChannel.kt
+++ b/app/src/main/java/com/team2052/frckrawler/notifications/FrcKrawlerNotificationChannel.kt
@@ -1,0 +1,18 @@
+package com.team2052.frckrawler.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import androidx.annotation.StringRes
+import com.team2052.frckrawler.R
+
+enum class FrcKrawlerNotificationChannel(
+  @StringRes val nameRes: Int,
+  @StringRes val descriptionRes: Int,
+  val id: String
+) {
+  Sync(
+    nameRes = R.string.notification_channel_sync_name,
+    descriptionRes = R.string.notification_channel_sync_description,
+    id = "sync"
+  )
+}

--- a/app/src/main/java/com/team2052/frckrawler/notifications/NotificationChannelManager.kt
+++ b/app/src/main/java/com/team2052/frckrawler/notifications/NotificationChannelManager.kt
@@ -1,0 +1,26 @@
+package com.team2052.frckrawler.notifications
+
+import android.app.NotificationChannel
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class NotificationChannelManager @Inject constructor(
+  @ApplicationContext private val context: Context
+) {
+
+  private val notificationManager = NotificationManagerCompat.from(context)
+
+  fun ensureChannelsCreated() {
+    FrcKrawlerNotificationChannel.values().forEach { channel ->
+      notificationManager.createNotificationChannel(
+        NotificationChannel(
+          channel.id,
+          context.getText(channel.nameRes),
+          NotificationManagerCompat.IMPORTANCE_DEFAULT
+        )
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/team2052/frckrawler/ui/bluetooth/RequestBluetoothEnable.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/bluetooth/RequestBluetoothEnable.kt
@@ -1,0 +1,63 @@
+package com.team2052.frckrawler.ui
+
+import android.app.Activity
+import android.bluetooth.BluetoothAdapter
+import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import com.team2052.frckrawler.R
+import com.team2052.frckrawler.data.model.DeviceType
+import com.team2052.frckrawler.ui.components.Alert
+
+/**
+ * Launch an activity to enable bluetooth.
+ * If the user does not enable bluetooth, show a dialog explaining that we need bluetooth
+ */
+@Composable
+fun RequestEnableBluetooth(
+  deviceType: DeviceType,
+  onEnabled: () -> Unit,
+  onCanceled: () -> Unit
+) {
+  var showCancelDialog by remember { mutableStateOf(false) }
+  val launcher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.StartActivityForResult(),
+    onResult = {
+      if (it.resultCode == Activity.RESULT_OK) {
+        onEnabled()
+      } else {
+        showCancelDialog = true
+      }
+    }
+  )
+
+  LaunchedEffect(true) {
+    launcher.launch(Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE))
+  }
+
+  if (showCancelDialog) {
+    Alert(
+      title = { Text(stringResource(R.string.bluetooth_enable_title)) },
+      description = {
+        val descriptionRes = when (deviceType) {
+          DeviceType.Server -> R.string.bluetooth_enable_server_description
+          DeviceType.Client -> R.string.bluetooth_enable_client_description
+        }
+        Text(stringResource(descriptionRes))
+      },
+      confirm = { Text(stringResource(R.string.ok)) },
+      onStateChange = {
+        showCancelDialog = false
+        onCanceled()
+      }
+    )
+  }
+}

--- a/app/src/main/java/com/team2052/frckrawler/ui/permissions/BluetoothPermissionRequests.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/permissions/BluetoothPermissionRequests.kt
@@ -1,0 +1,105 @@
+package com.team2052.frckrawler.ui.permissions
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.team2052.frckrawler.R
+import com.team2052.frckrawler.data.model.DeviceType
+import com.team2052.frckrawler.ui.components.Alert
+import com.team2052.frckrawler.ui.components.AlertState
+import com.team2052.frckrawler.ui.components.ComposableLauncher
+import com.team2052.frckrawler.ui.permissions.RequiredPermissions.serverPermissions
+import kotlinx.coroutines.launch
+
+
+/**
+ * Shows permission request dialogs if needed
+ */
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun BluetoothPermissionRequestDialogs(
+  deviceType: DeviceType,
+  onAllPermissionsGranted: () -> Unit,
+  onCanceled: () -> Unit
+) {
+  val permissions = rememberMultiplePermissionsState(
+    permissions = when (deviceType) {
+      DeviceType.Client -> RequiredPermissions.clientPermissions
+      DeviceType.Server -> RequiredPermissions.serverPermissions
+    }
+  )
+
+  if (!permissions.permissionRequested) {
+    if (permissions.shouldShowRationale) {
+      Alert(
+        confirm = { Text(stringResource(R.string.ok)) },
+        title = { Text(stringResource(R.string.bluetooth_permission_rationale_title)) },
+        description = {
+          val descriptionRes = when (deviceType) {
+            DeviceType.Client -> R.string.bluetooth_permission_rationale_description_client
+            DeviceType.Server -> R.string.bluetooth_permission_rationale_description_server
+          }
+          Text(stringResource(descriptionRes))
+        },
+        onStateChange = { permissions.launchMultiplePermissionRequest() }
+      )
+    } else {
+      LaunchedEffect(true) {
+        permissions.launchMultiplePermissionRequest()
+      }
+    }
+  }
+
+  if (permissions.permissionRequested && permissions.revokedPermissions.isNotEmpty()) {
+    val settingsIntent = getSettingsIntent()
+    val context = LocalContext.current
+
+    Alert(
+      confirm = { Text(stringResource(R.string.ok)) },
+      dismiss = { Text(stringResource(R.string.cancel)) },
+      title = { Text(stringResource(R.string.bluetooth_denied_title)) },
+      description = {
+        val descriptionRes = when (deviceType) {
+          DeviceType.Client -> R.string.bluetooth_denied_description_server
+          DeviceType.Server -> R.string.bluetooth_denied_description_client
+        }
+        Text(stringResource(descriptionRes))
+      },
+      onStateChange = { state ->
+        if (state == AlertState.CONFIRMED) {
+          context.startActivity(settingsIntent)
+        }
+
+        // We don't know if they did it or not, they need to re-try manually.
+        onCanceled()
+      }
+    )
+  }
+
+  if (permissions.allPermissionsGranted) {
+    LaunchedEffect(true) {
+      onAllPermissionsGranted()
+    }
+  }
+}
+
+@Composable
+private fun getSettingsIntent(): Intent {
+  val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+  intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+  val uri = Uri.fromParts("package", LocalContext.current.packageName, null)
+  intent.data = uri
+
+  return intent
+}
+

--- a/app/src/main/java/com/team2052/frckrawler/ui/permissions/PermissionManager.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/permissions/PermissionManager.kt
@@ -1,0 +1,10 @@
+package com.team2052.frckrawler.ui.permissions
+
+/**
+ * Abstraction over permission APIs to allow checking permission status without direct
+ * reference to a Context.
+ */
+interface PermissionManager {
+  fun hasPermission(permission: String): Boolean
+  fun hasPermissions(permissions: List<String>): Boolean
+}

--- a/app/src/main/java/com/team2052/frckrawler/ui/permissions/RealPermissionManager.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/permissions/RealPermissionManager.kt
@@ -1,0 +1,24 @@
+package com.team2052.frckrawler.ui.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/**
+ * Real permission manager implementation that checks a [Context] for permission status
+ */
+class RealPermissionManager @Inject constructor(
+  @ApplicationContext private val context: Context
+) : PermissionManager {
+  override fun hasPermission(permission: String): Boolean{
+    return context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+  }
+
+  override fun hasPermissions(permissions: List<String>): Boolean {
+    return permissions.all {
+      context.checkSelfPermission(it) == PackageManager.PERMISSION_GRANTED
+    }
+  }
+}

--- a/app/src/main/java/com/team2052/frckrawler/ui/permissions/RequiredPermissions.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/permissions/RequiredPermissions.kt
@@ -1,0 +1,36 @@
+package com.team2052.frckrawler.ui.permissions
+
+import android.os.Build
+
+/**
+ * Permissions required to use the app, split into client and server.
+ * These should be request when starting the server or first connecting a client to a server.
+ */
+object RequiredPermissions {
+  val serverPermissions = if (Build.VERSION.SDK_INT >= 31) {
+    listOf(
+      android.Manifest.permission.BLUETOOTH_CONNECT,
+    )
+  } else if (Build.VERSION.SDK_INT >= 26) {
+    // We will use CompanionDeviceManager on API 26+
+    emptyList()
+  } else {
+    listOf(
+      android.Manifest.permission.ACCESS_COARSE_LOCATION
+    )
+  }
+
+  val clientPermissions = if (Build.VERSION.SDK_INT >= 31) {
+    listOf(
+      android.Manifest.permission.BLUETOOTH_SCAN,
+      android.Manifest.permission.BLUETOOTH_CONNECT,
+    )
+  } else if (Build.VERSION.SDK_INT >= 26) {
+    // We will use CompanionDeviceManager on API 26+
+    emptyList()
+  } else {
+    listOf(
+      android.Manifest.permission.ACCESS_COARSE_LOCATION
+    )
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="bluetooth_Text">Bluetooth Server Running:</string>
     <string name="viewLogsButton">View Logs</string>
 
+    <!-- Common strings -->
+    <string name="ok">ok</string>
+    <string name="cancel">cancel</string>
+
     <!--Shared Preferences TODO: Should this be here?-->
     <string name="preference_app_mode">&applicationID;PREFERENCE_APP_MODE</string>
 
@@ -56,4 +60,29 @@
     <string name="metrics_screen">Metrics</string>
     <string name="match_metrics_screen">Match</string>
     <string name="pit_metrics_screen">Pit</string>
+
+    <!-- Permissions -->
+    <string name="bluetooth_permission_rationale_title">Permissions required</string>
+    <string name="bluetooth_permission_rationale_description_server">FRCKrawler requires bluetooth permissions to create a server. This will allow scouts to connect and sync data.</string>
+    <string name="bluetooth_permission_rationale_description_client">FRCKrawler requires bluetooth permissions to connect to a scouting server. This will allow syncing data between this device and the server.</string>
+    <string name="bluetooth_denied_title">Permissions required</string>
+    <string name="bluetooth_denied_description_server">FRCKrawler cannot enable the server without bluetooth permissions. Please enable the permissions in settings.</string>
+    <string name="bluetooth_denied_description_client">FRCKrawler cannot connect to a server without bluetooth permissions. Please enable the permissions in settings.</string>
+    <string name="bluetooth_denied_launch_settings">go to settings</string>
+
+    <!-- Enable bluetooth -->
+    <string name="bluetooth_enable_title">Bluetooth not enabled</string>
+    <string name="bluetooth_enable_server_description">Running an FRCKrawler server requires you to enable bluetooth. Please enable bluetooth and try again.</string>
+    <string name="bluetooth_enable_client_description">Connecting to an FRCKrawler server requires you to enable bluetooth. Please enable bluetooth and try again.</string>
+
+    <!-- Server syncing -->
+    <string name="server_sync_notification_title">FRCKrawler Server Running</string>
+    <plurals name="server_sync_clients_connected">
+        <item quantity="one">%1$d scout connected</item>
+        <item quantity="other">%1$d scouts connected</item>
+    </plurals>
+
+    <!-- Notifications -->
+    <string name="notification_channel_sync_name">Sync</string>
+    <string name="notification_channel_sync_description">Data sync notifications</string>
 </resources>


### PR DESCRIPTION
This got a little bit bigger than I expected, but this PR sets up the framework for the server side of Bluetooth.

With this you can now "start" the server and it'll start accepting bluetooth connections (but doesn't do anything beyond accept the connection at this point).

To support this I made a few changes to the server home screen to request the right permissions on the right API levels, and adjusting the way we present the permissions a little bit.