### PR TITLE
Add ability to disable metrics

### DIFF
--- a/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddEditMetricDialog.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddEditMetricDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -32,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -65,6 +67,7 @@ fun AddEditMetricDialog(
   AddEditMetricContent(
     state = state,
     mode = mode,
+    onEnabledChanged = { enabled -> viewModel.setEnabled(enabled) },
     onNameChange = { viewModel.updateName(it) },
     onTypeChange = { viewModel.updateType(it) },
     onSaveClick = {
@@ -104,6 +107,7 @@ fun AddEditMetricDialog(
 private fun AddEditMetricContent(
   state: AddEditMetricScreenState,
   mode: AddEditMetricMode,
+  onEnabledChanged: (Boolean) -> Unit,
   onNameChange: (String) -> Unit,
   onTypeChange: (MetricType) -> Unit,
   onOptionsChange: (MetricOptions) -> Unit,
@@ -134,6 +138,20 @@ private fun AddEditMetricContent(
         onValueChange = onNameChange,
         label = "Metric name"
       )
+
+      Spacer(Modifier.height(8.dp))
+
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        Text(text = stringResource(R.string.edit_metric_enabled_label))
+        Spacer(Modifier.width(12.dp))
+        Switch(
+          checked = state.enabled,
+          onCheckedChange = onEnabledChanged
+        )
+      }
 
       MetricTypeSelector(
         metricType = state.type,
@@ -450,6 +468,7 @@ private fun BooleanMetricPreview() {
       AddEditMetricContent(
         state = state,
         mode = AddEditMetricMode.New(),
+        onEnabledChanged = {},
         onNameChange = {},
         onTypeChange = {},
         onSaveClick = {},

--- a/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddEditMetricScreenState.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddEditMetricScreenState.kt
@@ -23,7 +23,7 @@ data class AddEditMetricScreenState(
         id = id,
         name = name,
         priority = priority,
-        enabled = true
+        enabled = enabled
       )
 
       MetricType.Counter -> {
@@ -32,7 +32,7 @@ data class AddEditMetricScreenState(
           id = id,
           name = name,
           priority = priority,
-          enabled = true,
+          enabled = enabled,
           range = options.range step options.step,
         )
       }
@@ -43,7 +43,7 @@ data class AddEditMetricScreenState(
           id = id,
           name = name,
           priority = priority,
-          enabled = true,
+          enabled = enabled,
           range = options.range
         )
       }
@@ -54,7 +54,7 @@ data class AddEditMetricScreenState(
           id = id,
           name = name,
           priority = priority,
-          enabled = true,
+          enabled = enabled,
           options = options.options
         )
       }
@@ -65,7 +65,7 @@ data class AddEditMetricScreenState(
           id = id,
           name = name,
           priority = priority,
-          enabled = true,
+          enabled = enabled,
           options = options.options
         )
       }
@@ -74,14 +74,14 @@ data class AddEditMetricScreenState(
         id = id,
         name = name,
         priority = priority,
-        enabled = true
+        enabled = enabled
       )
 
       MetricType.TextField -> Metric.TextFieldMetric(
         id = id,
         name = name,
         priority = priority,
-        enabled = true
+        enabled = enabled
       )
     }
   }

--- a/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddMetricViewModel.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddMetricViewModel.kt
@@ -47,6 +47,10 @@ class AddMetricViewModel @Inject constructor(
     )
   }
 
+  fun setEnabled(enabled: Boolean) {
+    _state.value = _state.value.copy(enabled = enabled)
+  }
+
   fun updateName(name: String) {
     // TODO add some visible validation messaging?
     _state.value = _state.value.copy(name = name)

--- a/app/src/main/java/com/team2052/frckrawler/ui/scout/AbstractScoutMetricsViewModel.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/scout/AbstractScoutMetricsViewModel.kt
@@ -60,6 +60,7 @@ abstract class AbstractScoutMetricsViewModel(
     .flatMapLatest { metricDao.getMetrics(it) }
     .map { metricRecords ->
       metricRecords.map { record -> record.toMetric() }
+        .filter { it.enabled }
     }
     .shareIn(
       viewModelScope,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
     <string name="metric_list_empty_text">No metrics</string>
 
     <string name="edit_metric_type_label">Metric type:</string>
+    <string name="edit_metric_enabled_label">Enabled</string>
     <string name="edit_metric_preview_label">Preview</string>
     <string name="add_metric_button_description">Add new metric</string>
 


### PR DESCRIPTION
Expose UI for changing enabled state on the add/edit metric dialog
Hide metrics that are not enabled on scouting screens