### PR TITLE
Fix priority changing when updating metrics

### DIFF
--- a/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddEditMetricScreenState.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddEditMetricScreenState.kt
@@ -6,7 +6,7 @@ import com.team2052.frckrawler.data.model.Metric
 data class AddEditMetricScreenState(
   val name: String = "",
   val type: MetricType = MetricType.Boolean,
-  val priority: Int = 0,
+  val priority: Int = -1,
   val enabled: Boolean = true,
   val options: MetricOptions = MetricOptions.None,
 ) {

--- a/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddMetricViewModel.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/metrics/edit/AddMetricViewModel.kt
@@ -76,7 +76,9 @@ class AddMetricViewModel @Inject constructor(
 
   fun save() {
     viewModelScope.launch {
-      val priority = metricRepo.getMetricCount(metricSetId)
+      val priority = if (_state.value.priority == -1) {
+        metricRepo.getMetricCount(metricSetId)
+      } else _state.value.priority
       val metric = _state.value.toMetric(
         id = metricId,
         priority = priority


### PR DESCRIPTION
Updating a metric was always moving it to the end of the list