### PR TITLE
Fix crash when analyzing team data for a team with data from a deleted event

### DIFF
--- a/app/src/main/java/com/team2052/frckrawler/data/local/EventDao.kt
+++ b/app/src/main/java/com/team2052/frckrawler/data/local/EventDao.kt
@@ -17,6 +17,9 @@ interface EventDao {
   @Query("SELECT * FROM event WHERE id = :id")
   suspend fun get(id: Int): Event
 
+  @Query("SELECT * FROM event WHERE id = :id")
+  suspend fun getOrNull(id: Int): Event?
+
   @Query("SELECT * FROM event WHERE gameId = :gameId")
   fun getAllForGame(gameId: Int): Flow<List<Event>>
 

--- a/app/src/main/java/com/team2052/frckrawler/ui/analyze/team/TeamDataViewModel.kt
+++ b/app/src/main/java/com/team2052/frckrawler/ui/analyze/team/TeamDataViewModel.kt
@@ -10,11 +10,11 @@ import com.team2052.frckrawler.data.local.TeamAtEventDao
 import com.team2052.frckrawler.data.model.Metric
 import com.team2052.frckrawler.data.summary.SummaryValue
 import com.team2052.frckrawler.data.summary.getSummarizer
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
-import dev.zacsweers.metro.AppScope
 import com.team2052.frckrawler.repository.MetricRepository
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -77,7 +77,10 @@ class TeamDataViewModel(
   private suspend fun getTeamDataByEvent(teamNumber: String): Map<Event, List<MetricDatum>> {
     val allData = metricDataDao.getAllTeamDatum(teamNumber)
     val dataByEventId = allData.groupBy { it.eventId }
-    return dataByEventId.mapKeys { (id, _) -> eventDao.get(id) }
+    val teamByEventsOrNull = dataByEventId.mapKeys { (id, _) -> eventDao.getOrNull(id) }
+
+    @Suppress("UNCHECKED_CAST")
+    return teamByEventsOrNull.filterKeys { it != null } as Map<Event, List<MetricDatum>>
   }
 
   private fun summarizeTeamData(


### PR DESCRIPTION
If an event is deleted any lingering team data referencing it will create a crash when we try to fetch the event.

We may want to more fully delete data from deleted events, but for now this will resolve the crash and preserve the data.